### PR TITLE
Put All jquery event attachments inside $(document).ready function.

### DIFF
--- a/js/user-func.js
+++ b/js/user-func.js
@@ -1,6 +1,5 @@
-$(function()
-{
-    // Скользящее меню
+$( document ).ready(function() 
+{    // Скользящее меню
     $(".h-menu li").hover(
         function() {
             $(this).stop().animate({width: "235px"}, 500);
@@ -17,14 +16,265 @@ $(function()
         $(this).toggleClass("active");
         $(this).next().toggle();
     });
-});
 
-// Меню
-$(".h-menu li").click(function() {
-    $(".h-menu li").stop().animate({width: "27px"}, 500);
-    $(".h-menu li").removeClass("active");
-    $(this).stop().animate({width: "235px"}, 500);
-    $(this).addClass("active");
+    // Меню
+    $(".h-menu li").click(function() {
+        $(".h-menu li").stop().animate({width: "27px"}, 500);
+        $(".h-menu li").removeClass("active");
+        $(this).stop().animate({width: "235px"}, 500);
+        $(this).addClass("active");
+    });
+
+    //Передаём пароль
+    $("#enter").submit(function() {
+        var $form = $(this),p = $form.find('input[name="password"]').val();
+        $('#notice').empty().append('Обрабатывается запрос...').fadeIn();
+        $.post("action.php",{action: 'enter', password: p},
+            function(data) {
+                if (data.error)
+                    $('#notice').empty().attr('background', '#FF6633').append(data.msg).delay(3000).fadeOut(400);
+                else
+                    document.location.reload();
+                console.log(data.error)
+            }, "json"
+        );
+        
+        return false;
+    });
+
+    //Передаём тему для мониторинга
+    $("#torrent_add").submit(function()
+    {
+        var $form = $(this),
+            s = $form.find('input[type=submit]'),
+            n_f = $form.find('input[name="name"]'),
+            n = $(n_f).val(),
+            u_f = $form.find('input[name="url"]'),
+            u = $(u_f).val(),
+            p_f = $form.find('input[name="path"]'),
+            p = $(p_f).val(); 
+        
+        if (u == '')
+        {
+            alert("Вы не указали ссылку на тему!");
+            return false;
+        }
+                                    
+        $('#notice').empty().append('Обрабатывается запрос...').fadeIn();
+        $.post("action.php",{action: 'torrent_add', name: n, url: u, path: p},
+            function(data) {
+                $('#notice').empty().append(data).delay(3000).fadeOut(400);
+                $(n_f).val('');
+                $(u_f).val('');
+            }
+        );
+        return false;
+    });
+
+    //Передаём сериал для мониторинга
+    $("#serial_add").submit(function()
+    {
+        var $form = $(this),
+            s = $form.find('input[type=submit]'),
+            t = $form.find('select[name="tracker"]').val(),
+            n_f = $form.find('input[name="name"]'),
+            n = $(n_f).val(),
+            h_f = $form.find('input[name="hd"]'),
+            p_f = $form.find('input[name="path"]'),
+            p = $(p_f).val();
+
+        h = $(h_f).val();
+        for (var i = 0; i < h_f.length; i++)
+        {
+            if (h_f[i].checked)
+            {
+                var $form = $(this), h = h_f[i].value
+            }
+        }
+
+        if (t == '')
+        {
+            alert("Вы не выбрали трекер!");
+            return false;
+        }
+        
+        if (n == '')
+        {
+            alert("Вы не указали название сериала!");
+            return false;
+        }     
+
+        $('#notice').empty().append('Обрабатывается запрос...').fadeIn();
+        $.post("action.php",{action: 'serial_add', tracker: t, name: n, hd: h, path: p},
+            function(data) {
+                $('#notice').empty().attr('background', '#FF6633').append(data).delay(3000).fadeOut(400);
+                $(n_f).val('');
+                $(h_f).removeAttr('checked');
+            }
+        );
+        return false;
+    });
+
+    //Передаём пользователя для мониторинга
+    $("#user_add").submit(function()
+    {
+        var $form = $(this),
+            s = $form.find('input[type=submit]'),
+            t = $form.find('select[name="tracker"]').val(),
+            n_f = $form.find('input[name="name"]'),
+            n = $(n_f).val();
+
+        if (t == '')
+        {
+            alert("Вы не выбрали трекер!");
+            return false;
+        }
+        
+        if (n == '')
+        {
+            alert("Вы не указали имя пользователя!");
+            return false;
+        }    
+        
+        $('#notice').empty().append('Обрабатывается запрос...').fadeIn();
+        $.post("action.php",{action: 'user_add', tracker: t, name: n},
+            function(data) {
+                $('#notice').empty().attr('background', '#FF6633').append(data).delay(3000).fadeOut(400);
+                $(n_f).val('');
+            }
+        );
+        return false;
+    });
+    
+    //Удаляем темы 
+    $("#threme_clear").submit(function()
+    {
+        $('#notice').empty().append('Обрабатывается запрос...').fadeIn();
+        $.post("action.php",{action: 'threme_clear'},
+            function(data) {
+                $('#notice').empty().attr('background', '#FF6633').append(data).delay(3000).fadeOut(400);
+                $.get("include/show_watching.php",
+                    function(data) {
+                        $('#content').empty().append(data);
+                    }
+                );
+            }
+        );
+        return false;
+    });
+
+    //Передаём личные данные
+    $("#credential").submit(function()
+    {
+        var $form = $(this),
+            b = $form.find('input[type=button]'),
+            id = $form.find('input[name="id"]').val(),
+            l = $form.find('input[name="log"]').val(),
+            p = $form.find('input[name="pass"]').val();
+
+        if (l == '')
+        {
+            alert("Вы не указали логин!");
+            return false;
+        }
+        
+        if (p == '')
+        {
+            alert("Вы не указали пароль!");
+            return false;
+        }	
+                                    
+        $('#notice').empty().append('Обрабатывается запрос...').fadeIn();
+        $.post("action.php",{action: 'update_credentials', id: id, log: l, pass: p},
+            function(data) {
+                $('#notice').empty().attr('background', '#FF6633').append(data).delay(3000).fadeOut(400);
+                $(b).removeAttr('disabled');
+            }
+        );
+        return false;
+    });
+        
+    //Передаём настройки
+    $("#setting").submit(function()
+    {
+        var $form = $(this),
+            s = $form.find('input[type=submit]'),
+            p = $form.find('input[name="path"]').val(),
+            e = $form.find('input[name="email"]').val(),
+            s = $form.find('input[name="send"]').prop('checked');
+            s_w = $form.find('input[name="send_warning"]').prop('checked');
+            a = $form.find('input[name="auth"]').prop('checked');
+            pr = $form.find('input[name="proxy"]').prop('checked');
+            pa = $form.find('input[name="proxyAddress"]').val();
+            t = $form.find('input[name="torrent"]').prop('checked');
+            tc = $form.find('select[name="torrentClient"]').val();
+            ta = $form.find('input[name="torrentAddress"]').val();
+            tl = $form.find('input[name="torrentLogin"]').val();
+            tp = $form.find('input[name="torrentPassword"]').val();
+            ptd = $form.find('input[name="pathToDownload"]').val();
+            dt = $form.find('input[name="deleteTorrent"]').prop('checked');
+            dof = $form.find('input[name="deleteOldFiles"]').prop('checked');
+        
+        if (p == '')
+        {
+            alert('Вы не указали путь сохранения torrent-файлов.');
+            return false;
+        }
+        
+        if (pr == 'checked' && pa == '')
+        {
+            alert('Вы не указали адрес proxy-сервера.');
+            return false;
+        }
+        
+        if (t == 'checked' && tc == ''  && ta == '' && ptd == '')
+        {
+            alert('Вы не указали настройки торрент-клиента.');
+            return false;
+        }
+        
+        $('#notice').empty().append('Обрабатывается запрос...').fadeIn();
+        $.post("action.php",{action: 'update_settings', path: p, email: e, send: s, send_warning: s_w, auth: a, proxy: pr, proxyAddress: pa, torrent: t, torrentClient: tc, torrentAddress: ta, torrentLogin: tl, torrentPassword: tp, pathToDownload: ptd, deleteTorrent: dt, deleteOldFiles: dof},
+            function(data) {
+                $('#notice').empty().attr('background', '#FF6633').append(data).delay(3000).fadeOut(400);
+                $(s).removeAttr('disabled');
+            }
+        );
+        return false;
+    });
+
+    //Передаём пароль
+    $("#change_pass").submit(function()
+    {
+        var $form = $(this),
+            s = $form.find('input[type=submit]'),
+            p = $form.find('input[name="password"]').val(),
+            p2 = $form.find('input[name="password2"]').val();
+            
+        if (p == '')
+        {
+            alert('Пароль не может быть пустым.');
+            return false;
+        }
+        
+        if (p != p2) 
+        {
+            alert('Пароль и подтверждение должны совпадать.');
+            return false;
+        }
+        
+        $('#notice').empty().append('Обрабатывается запрос...').fadeIn();
+        $.post("action.php",{action: 'change_pass', pass: p},
+            function(data) {
+                if (data.error)
+                    $('#notice').empty().attr('background', '#FF6633').append(data).delay(3000).fadeOut(400);
+                else
+                    document.location.reload();
+            }, "json"
+        );
+        return false;
+    });
+
 });
 
 //Подгрузка страниц
@@ -68,126 +318,6 @@ function expand(id)
 	return false;
 }
 
-//Передаём пароль
-$("#enter").submit(function() {
-	var $form = $(this),p = $form.find('input[name="password"]').val();
-	$('#notice').empty().append('Обрабатывается запрос...').fadeIn();
-	$.post("action.php",{action: 'enter', password: p},
-		function(data) {
-			if (data.error)
-				$('#notice').empty().attr('background', '#FF6633').append(data.msg).delay(3000).fadeOut(400);
-			else
-          		document.location.reload();
-          	console.log(data.error)
-		}, "json"
-	);
-	
-	return false;
-});
-
-//Передаём тему для мониторинга
-$("#torrent_add").submit(function()
-{
-	var $form = $(this),
-		s = $form.find('input[type=submit]'),
-		n_f = $form.find('input[name="name"]'),
-		n = $(n_f).val(),
-		u_f = $form.find('input[name="url"]'),
-		u = $(u_f).val(),
-		p_f = $form.find('input[name="path"]'),
-		p = $(p_f).val(); 
-	
-    if (u == '')
-    {
-    	alert("Вы не указали ссылку на тему!");
-    	return false;
-    }
-								
-	$('#notice').empty().append('Обрабатывается запрос...').fadeIn();
-	$.post("action.php",{action: 'torrent_add', name: n, url: u, path: p},
-		function(data) {
-			$('#notice').empty().append(data).delay(3000).fadeOut(400);
-			$(n_f).val('');
-			$(u_f).val('');
-		}
-	);
-	return false;
-});
-
-//Передаём сериал для мониторинга
-$("#serial_add").submit(function()
-{
-	var $form = $(this),
-		s = $form.find('input[type=submit]'),
-		t = $form.find('select[name="tracker"]').val(),
-		n_f = $form.find('input[name="name"]'),
-		n = $(n_f).val(),
-		h_f = $form.find('input[name="hd"]'),
-		p_f = $form.find('input[name="path"]'),
-		p = $(p_f).val();
-
-	h = $(h_f).val();
-	for (var i = 0; i < h_f.length; i++)
-	{
-		if (h_f[i].checked)
-		{
-			var $form = $(this), h = h_f[i].value
-		}
-	}
-
-    if (t == '')
-    {
-    	alert("Вы не выбрали трекер!");
-    	return false;
-    }
-    
-    if (n == '')
-    {
-    	alert("Вы не указали название сериала!");
-    	return false;
-    }     
-
-	$('#notice').empty().append('Обрабатывается запрос...').fadeIn();
-	$.post("action.php",{action: 'serial_add', tracker: t, name: n, hd: h, path: p},
-		function(data) {
-			$('#notice').empty().attr('background', '#FF6633').append(data).delay(3000).fadeOut(400);
-			$(n_f).val('');
-			$(h_f).removeAttr('checked');
-		}
-	);
-	return false;
-});
-
-//Передаём пользователя для мониторинга
-$("#user_add").submit(function()
-{
-	var $form = $(this),
-		s = $form.find('input[type=submit]'),
-		t = $form.find('select[name="tracker"]').val(),
-		n_f = $form.find('input[name="name"]'),
-		n = $(n_f).val();
-
-    if (t == '')
-    {
-    	alert("Вы не выбрали трекер!");
-    	return false;
-    }
-    
-    if (n == '')
-    {
-    	alert("Вы не указали имя пользователя!");
-    	return false;
-    }    
-	
-	$('#notice').empty().append('Обрабатывается запрос...').fadeIn();
-	$.post("action.php",{action: 'user_add', tracker: t, name: n},
-		function(data) {
-			$('#notice').empty().attr('background', '#FF6633').append(data).delay(3000).fadeOut(400);
-			$(n_f).val('');
-		}
-	);
-	return false;
-});
 
 //Удаляем пользователя
 function delete_user(id)
@@ -269,135 +399,6 @@ function threme_add(id, user_id)
 	);
 	return false;
 }
-
-//Удаляем темы 
-$("#threme_clear").submit(function()
-{
-	$('#notice').empty().append('Обрабатывается запрос...').fadeIn();
-	$.post("action.php",{action: 'threme_clear'},
-		function(data) {
-			$('#notice').empty().attr('background', '#FF6633').append(data).delay(3000).fadeOut(400);
-			$.get("include/show_watching.php",
-				function(data) {
-					$('#content').empty().append(data);
-				}
-			);
-		}
-	);
-	return false;
-});
-
-//Передаём личные данные
-$("#credential").submit(function()
-{
-	var $form = $(this),
-		b = $form.find('input[type=button]'),
-		id = $form.find('input[name="id"]').val(),
-		l = $form.find('input[name="log"]').val(),
-		p = $form.find('input[name="pass"]').val();
-
-	if (l == '')
-	{
-		alert("Вы не указали логин!");
-		return false;
-	}
-	
-	if (p == '')
-	{
-		alert("Вы не указали пароль!");
-		return false;
-	}	
-								
-	$('#notice').empty().append('Обрабатывается запрос...').fadeIn();
-	$.post("action.php",{action: 'update_credentials', id: id, log: l, pass: p},
-		function(data) {
-			$('#notice').empty().attr('background', '#FF6633').append(data).delay(3000).fadeOut(400);
-			$(b).removeAttr('disabled');
-		}
-	);
-	return false;
-});
-	
-//Передаём настройки
-$("#setting").submit(function()
-{
-	var $form = $(this),
-		s = $form.find('input[type=submit]'),
-		p = $form.find('input[name="path"]').val(),
-		e = $form.find('input[name="email"]').val(),
-		s = $form.find('input[name="send"]').prop('checked');
-		s_w = $form.find('input[name="send_warning"]').prop('checked');
-		a = $form.find('input[name="auth"]').prop('checked');
-		pr = $form.find('input[name="proxy"]').prop('checked');
-		pa = $form.find('input[name="proxyAddress"]').val();
-		t = $form.find('input[name="torrent"]').prop('checked');
-		tc = $form.find('select[name="torrentClient"]').val();
-		ta = $form.find('input[name="torrentAddress"]').val();
-		tl = $form.find('input[name="torrentLogin"]').val();
-		tp = $form.find('input[name="torrentPassword"]').val();
-		ptd = $form.find('input[name="pathToDownload"]').val();
-		dt = $form.find('input[name="deleteTorrent"]').prop('checked');
-		dof = $form.find('input[name="deleteOldFiles"]').prop('checked');
-	
-	if (p == '')
-	{
-		alert('Вы не указали путь сохранения torrent-файлов.');
-		return false;
-	}
-	
-	if (pr == 'checked' && pa == '')
-	{
-		alert('Вы не указали адрес proxy-сервера.');
-		return false;
-	}
-	
-	if (t == 'checked' && tc == ''  && ta == '' && ptd == '')
-	{
-    	alert('Вы не указали настройки торрент-клиента.');
-		return false;
-	}
-	
-	$('#notice').empty().append('Обрабатывается запрос...').fadeIn();
-	$.post("action.php",{action: 'update_settings', path: p, email: e, send: s, send_warning: s_w, auth: a, proxy: pr, proxyAddress: pa, torrent: t, torrentClient: tc, torrentAddress: ta, torrentLogin: tl, torrentPassword: tp, pathToDownload: ptd, deleteTorrent: dt, deleteOldFiles: dof},
-		function(data) {
-			$('#notice').empty().attr('background', '#FF6633').append(data).delay(3000).fadeOut(400);
-			$(s).removeAttr('disabled');
-		}
-	);
-	return false;
-});
-
-//Передаём пароль
-$("#change_pass").submit(function()
-{
-	var $form = $(this),
-		s = $form.find('input[type=submit]'),
-		p = $form.find('input[name="password"]').val(),
-		p2 = $form.find('input[name="password2"]').val();
-		
-	if (p == '')
-	{
-    	alert('Пароль не может быть пустым.');
-		return false;
-	}
-	
-	if (p != p2) 
-	{
-		alert('Пароль и подтверждение должны совпадать.');
-		return false;
-	}
-	
-	$('#notice').empty().append('Обрабатывается запрос...').fadeIn();
-	$.post("action.php",{action: 'change_pass', pass: p},
-		function(data) {
-			if (data.error)
-				$('#notice').empty().attr('background', '#FF6633').append(data).delay(3000).fadeOut(400);
-			else
-				document.location.reload();
-		}, "json"
-	);
-	return false;
-});
 
 //Удаляем мониторинг
 function del(id)


### PR DESCRIPTION
Согласно документации jquery (см.напр. http://jquery-docs.ru/events/ready/ , http://api.jquery.com/ready/) все действия с докментом (в том числе - навешивание событий на элементы DOM) должны производиться после полной загрузки докмента.
И лучшее место для этого - фукнция $(document).ready()
Я просто перенес все навешивания событий внутрь этой функции.
А то я раньше недоумевал, почему все скрипты в документе лежат в футере, а не в заголовке, как обычно.
Попробовал перенести в заголовок - все отъехало. 
А проблема была именно в неправильном месте навешивания событий.
Теперь все работает нормально, и подключение скриптов можно перенести из footer.php на их законное место в headсекцию.
