### PR TITLE
fix rss

### DIFF
--- a/rss/index.php
+++ b/rss/index.php
@@ -11,7 +11,6 @@ if ($rss)
     <channel>
     <title>TorrentMonitor RSS</title>
     <?php
-    $dir = dirname(__FILE__)."/";
     include_once $dir."config.php";
     include_once $dir."class/Database.class.php";
 


### PR DESCRIPTION
Переменная $dir была инициализирована выше. В этой строке путь определяется не верно, из-за чего при формировании ленты получаю ошибку:
<b>Warning</b>:  include_once(/mnt/HD/HD_a2/Nas_Prog/torrentmonitor/php/rss/config.php): failed to open stream: No such file or directory in <b>/mnt/HD/HD_a2/Nas_Prog/torrentmonitor/php/rss/index.php</b> on line <b>15</b><br /><br />
<b>Warning</b>:  include_once(): Failed opening '/mnt/HD/HD_a2/Nas_Prog/torrentmonitor/php/rss/config.php' for inclusion (include_path='.:') in <b>/mnt/HD/HD_a2/Nas_Prog/torrentmonitor/php/rss/index.php</b> on line <b>15</b><br /><br />
<b>Warning</b>:  include_once(/mnt/HD/HD_a2/Nas_Prog/torrentmonitor/php/rss/class/Database.class.php): failed to open stream: No such file or directory in <b>/mnt/HD/HD_a2/Nas_Prog/torrentmonitor/php/rss/index.php</b> on line <b>16</b><br /><br />
<b>Warning</b>:  include_once(): Failed opening '/mnt/HD/HD_a2/Nas_Prog/torrentmonitor/php/rss/class/Database.class.php' for inclusion (include_path='.:') in <b>/mnt/HD/HD_a2/Nas_Prog/torrentmonitor/php/rss/index.php</b> on line <b>16</b><br />