### PR TITLE
Pushover: исправление заголовка и добавление приоритета

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/class/Errors.class.php
+++ b/class/Errors.class.php
@@ -20,6 +20,7 @@ class Errors
     	Errors::write('duplicate_torrent', 'Не удалось добавить в torrent-клиент, такая закачка уже запущена.');
     	Errors::write('404', 'Не удалось добавить в torrent-клиент, не верная ссылка на torrent-файл.');
     	Errors::write('unauthorized', 'Не удалось добавить в torrent-клиент, не прошла авторизация в torrent-клиенте.');
+    	Errors::write('mail_fail', 'Не удалось отправить уведомление на электронную почту. Настройте MTA!');
 	}
 	
 	public static function getInstance()

--- a/class/Notification.class.php
+++ b/class/Notification.class.php
@@ -40,10 +40,10 @@ class Notification
 		mail($settingEmail, '=?UTF-8?B?'.base64_encode("TorrentMonitor: ".$header_message).'?=', $msg, $headers);
 	}
 	
-	public static function sendPushover($sendUpdatePushover, $date, $tracker, $message)
+	public static function sendPushover($sendUpdatePushover, $date, $tracker, $message, $header_message, $priority=0)
 	{
 	    $msg = 'Дата: '.$date."\r\n".'Трекер: '.$tracker."\r\n".'Сообщение: '.$message."\r\n";
-        $postfields = 'token=a9784KuYUoUdT4z47BassBLxWQGqFV&user='.$sendUpdatePushover.'&message='.$msg;
+        $postfields = 'token=a9784KuYUoUdT4z47BassBLxWQGqFV&user='.$sendUpdatePushover.'&message='.$msg.'&title=TorrentMonitor: '.$header_message.'&priority='.$priority;
         $forumPage = Sys::getUrlContent(
         	array(
         		'type'           => 'POST',
@@ -76,7 +76,7 @@ class Notification
                         
                     $sendWarningPushover = Database::getSetting('sendWarningPushover');
                     if ( ! empty($sendWarningPushover))
-                        Notification::sendPushover($sendWarningPushover, $date, $tracker, $message, $header_message);
+                        Notification::sendPushover($sendWarningPushover, $date, $tracker, $message, $header_message, 1);
                 }
             }
 
@@ -91,7 +91,7 @@ class Notification
                         
                     $sendUpdatePushover = Database::getSetting('sendUpdatePushover');
                     if ( ! empty($sendUpdatePushover))
-                        Notification::sendPushover($sendUpdatePushover, $date, $tracker, $message, $header_message);
+                        Notification::sendPushover($sendUpdatePushover, $date, $tracker, $message, $header_message, 0);
                 }
             }
 		}

--- a/class/Notification.class.php
+++ b/class/Notification.class.php
@@ -37,7 +37,9 @@ class Notification
     		    $msg .= "http://casstudio.tv/viewtopic.php?t={$name}";
         }
 
-		mail($settingEmail, '=?UTF-8?B?'.base64_encode("TorrentMonitor: ".$header_message).'?=', $msg, $headers);
+		$mail_result = mail($settingEmail, '=?UTF-8?B?'.base64_encode("TorrentMonitor: ".$header_message).'?=', $msg, $headers);
+		if (!$mail_result)
+			Errors::setWarnings('system', 'mail_fail');
 	}
 	
 	public static function sendPushover($sendUpdatePushover, $date, $tracker, $message, $header_message, $priority=0)


### PR DESCRIPTION
Теперь в заголовке пуш-уведомления указано "Обновление" или "Предупреждение".
Также, пуш с предупреждением отправляется с повышенным приоритетом (выделяется красным)

Пример на скриншоте.

(порядок - сверху вниз)
Первый - так выглядит уведомление с ошибкой
Второй пуш - так выглядит обычный пуш с обновлением
Третий пуш - так было с ошибкой
Четвертый пуш - так было с обновлением
![plkauxhkc_w](https://cloud.githubusercontent.com/assets/6261028/6700081/c0b15944-cd19-11e4-88f5-b484bf9ff2a0.jpg)

