### PR TITLE
Чиню Deluge

### DIFF
--- a/class/System.class.php
+++ b/class/System.class.php
@@ -274,11 +274,7 @@ class Sys
         $torrentClient = Database::getSetting('torrentClient');
         $dir = dirname(__FILE__).'/';
         include_once $dir.$torrentClient.'.class.php';
-        $server = Database::getSetting('serverAddress');
-        $url = $server.$path;
-        $dir = str_replace('class/', '', $dir);
-        $url = str_replace($dir, '', $url);
-        $status = call_user_func($torrentClient.'::addNew', $id, $url, $hash, $tracker);
+        $status = call_user_func($torrentClient.'::addNew', $id, $path, $hash, $tracker);
         if ($status['status'])
         {
             Database::deleteFromTemp($id);

--- a/class/Transmission.class.php
+++ b/class/Transmission.class.php
@@ -7,6 +7,9 @@ class Transmission
     #добавляем новую закачку в torrent-клиент, обновляем hash в базе
     public static function addNew($id, $file, $hash, $tracker)
     {
+        $server = Database::getSetting('serverAddress');
+        $url = $server.str_replace(str_replace('class/', '', $dir), '', $file);
+
         #получаем настройки из базы
         $settings = Database::getAllSetting();
         foreach ($settings as $row)
@@ -43,7 +46,7 @@ class Transmission
     	    }
 
             #добавляем торрент в torrent-клиент
-            $result = $rpc->add($file, $pathToDownload);
+            $result = $rpc->add($url, $pathToDownload);
             $command = $result->result;
             $idt = @$result->arguments->torrent_added->id;
         


### PR DESCRIPTION
Deluge в качестве параметра принимает путь к файлу на диске. В отличие от Transmission, который принимает url. Т.к. путь к файлу торрента — более "базовая" переменная, переделывать её в url имеет смысл только в классе Transmission. Класс Deluge должен получать path неизменным.

Без этого патча Deluge получала команду вроде `add -p "/path/to/download" http://server/torrent/filename.torrent`. Разумеется, файл `http://server/torrent/filename.torrent` нельзя было прочитать с диска, и Deluge возвращал ошибку.