### PR TITLE
Quality select [lostfilm]

### DIFF
--- a/trackers/lostfilm.tv.engine.php
+++ b/trackers/lostfilm.tv.engine.php
@@ -162,24 +162,19 @@ class lostfilmtv
     {
         if (preg_match('/'.$name.'/i', $item->title))
         {
-            if ($hd == 1)
+            if ($hd == 0)
             {
-                if (preg_match_all('/1080/', $item->title, $matches))
+                if (preg_match_all('/avi|AVI/', $item->link, $matches))
                     return lostfilmtv::analysisEpisode($item);
-                else
-                {
-                    if (preg_match_all('/720|HD/', $item->title, $matches))
-                        return lostfilmtv::analysisEpisode($item);
-                }
+            }
+            elseif ($hd == 1)
+            {
+                if (preg_match_all('/mkv|MKV/', $item->link, $matches))
+                    return lostfilmtv::analysisEpisode($item);
             }
             elseif ($hd == 2)
             {
-                if (preg_match_all('/MP4/', $item->title, $matches))
-                    return lostfilmtv::analysisEpisode($item);
-            }
-            else
-            {
-                if (preg_match_all('/^(?!(.*720|.*HD|.*1080))/', $item->link, $matches))
+                if (preg_match_all('/mp4|MP4/', $item->link, $matches))
                     return lostfilmtv::analysisEpisode($item);
             }
         }


### PR DESCRIPTION
Привет,

Предлагаю изменить выбор качества c парсинга title, на парсинг link.
Нам известно что в имени torrent файла(ссылки на него):
* avi это всегда SD,
* mkv это всегда 720/1080 (я не слежу особо за этой позицией, но мне кажется 720 уже нет вообще?),
* mp4 это mp4 :)

Потому как в title, они почему то перестали указывать качество:
![screenshot 2015-04-05 10 14 54](https://cloud.githubusercontent.com/assets/2987792/6996121/a55c5146-db7c-11e4-95c2-abdfeacd4fcc.png)
