### PR TITLE
LostFilm: SD quality filename

### DIFF
--- a/trackers/lostfilm.tv.engine.php
+++ b/trackers/lostfilm.tv.engine.php
@@ -352,7 +352,7 @@ class lostfilmtv
                                 elseif ($hd == 2)
                                     $amp = 'MP4';
                                 else
-                                    $amp = NULL;
+                                    $amp = 'SD';
                                 //сохраняем торрент в файл
                                 $torrent = Sys::getUrlContent(
                                     array(


### PR DESCRIPTION
Привет,

Заметил при тестах такую особенность, что при SD качестве torrent файлик именуется как ```[lostfilm.tv]_Vikings.S03E07..torrent```, те там 2 точки подряд.