### PR TITLE
add CURLPROXY_SOCKS5_HOSTNAME

### DIFF
--- a/class/System.class.php
+++ b/class/System.class.php
@@ -205,7 +205,7 @@ class Sys
             {
                 curl_setopt($ch, CURLOPT_PROXY, $proxyAddress);
                 if ($proxyType == 'SOCKS5')
-                    curl_setopt($ch, CURLOPT_PROXYTYPE, CURLPROXY_SOCKS5);
+                    curl_setopt($ch, CURLOPT_PROXYTYPE, CURLPROXY_SOCKS5_HOSTNAME);
                 elseif ($proxyType == 'HTTP')
                     curl_setopt($ch, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
             }


### PR DESCRIPTION
в параметрах курла, при работе через сокс, можно указать что домен резолвить через эту проксю.
`CURLPROXY_SOCKS5` = `curl -x socks5://прокси:порт https://домен/блабла`
`CURLPROXY_SOCKS5_HOSTNAME` = `curl -x socks5h://прокси:порт https://домен/блабла`
