### PR TITLE
Fix for compatibility with the new version of qBittorrent WebAPI

### DIFF
--- a/class/qBittorrent.class.php
+++ b/class/qBittorrent.class.php
@@ -83,10 +83,12 @@ class qBittorrent
             CURLOPT_COOKIE => $cookie,
             CURLOPT_POSTFIELDS => $data
         ));
-        $response = curl_exec($ch);
+        curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
         curl_close($ch);
 
-        if (preg_match('/Ok/', $response)) {
+        //ожидаем код 200 при успешном добавлении нового и код 202, если торрент уже существует
+        if ($httpCode >= 200 && $httpCode <= 204) {
             sleep(3);
             
             //получение хэша торрента


### PR DESCRIPTION
Fix for compatibility with the new version of qBittorrent [WebAPI](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)):
1. https://github.com/qbittorrent/qBittorrent/pull/23202
WebAPI responds with the error message "Endpoint does not exist" when the endpoint does not exist, to better differentiate from unrelated Not Found (i.e. 404) responses;
auth/login endpoint responds to invalid credentials with a 401;
**torrents/add** endpoint responds with success_count, pending_count, failure_count, and added_torrent_ids:
-     When pending_count is non-zero, response code 202 is used
-     When all torrents fail to be added, response code 409 is used
2. https://github.com/qbittorrent/qBittorrent/pull/21349
Handle sending **204 No Content** status code when response contains no data;
Some endpoints still return 200 OK to ensure smooth transition;
