### PR TITLE
FlareSolverr: forward the configured per-tracker proxy

### DIFF
--- a/class/System.class.php
+++ b/class/System.class.php
@@ -188,6 +188,21 @@ class Sys
         return $options;
     }
 
+    //конвертирует curl-опции прокси (getProxyOptions) в URL-строку для FlareSolverr's
+    //JSON API ("proxy": {"url": "..."}) -- FlareSolverr не умеет CURLOPT_PROXY/CURLOPT_PROXYTYPE,
+    //только явную схему в URL
+    private static function proxyOptionsToUrl($options)
+    {
+        if (empty($options[CURLOPT_PROXY]))
+            return null;
+
+        $scheme = 'http';
+        if (isset($options[CURLOPT_PROXYTYPE]) && $options[CURLOPT_PROXYTYPE] == CURLPROXY_SOCKS5_HOSTNAME)
+            $scheme = 'socks5h';
+
+        return $scheme.'://'.$options[CURLOPT_PROXY];
+    }
+
     //обёртка для CURL, для более удобного использования
     public static function getUrlContent($param = null)
     {
@@ -319,6 +334,14 @@ class Sys
         );
         if ($method == 'POST')
             $requestParams['postData'] = $postData;
+
+        //прокидываем уже настроенный (в т.ч. потрекерный) прокси в FlareSolverr -- без
+        //этого FlareSolverr ходит на сайт напрямую со своего хоста, и для трекеров,
+        //заблокированных на уровне DPI/ISP (а не только Cloudflare-челленджем), запрос
+        //не проходит даже после решения челленджа
+        $proxyUrl = Sys::proxyOptionsToUrl(Sys::getProxyOptions($url));
+        if ($proxyUrl)
+            $requestParams['proxy'] = array('url' => $proxyUrl);
 
         $requestJson = json_encode($requestParams);
 

--- a/class/System.class.php
+++ b/class/System.class.php
@@ -198,7 +198,7 @@ class Sys
 
         $scheme = 'http';
         if (isset($options[CURLOPT_PROXYTYPE]) && $options[CURLOPT_PROXYTYPE] == CURLPROXY_SOCKS5_HOSTNAME)
-            $scheme = 'socks5h';
+            $scheme = 'socks5';
 
         return $scheme.'://'.$options[CURLOPT_PROXY];
     }


### PR DESCRIPTION
Этот PR добавляет проброс прокси в `Sys::getViaFlareSolverr()`.

**Проблема:** `getProxyOptions()` уже собирает настройки прокси для каждого трекера (общие + переопределение через `ext_proxy`) для обычных curl-запросов, но `getViaFlareSolverr()` никогда не передаёт их в собственный `/v1` API FlareSolverr. FlareSolverr делает запрос напрямую оттуда, где он размещён, вообще без прокси. Это нормально, когда трекер закрыт только Cloudflare-челленджем, но молча ломается для трекеров, которые *вдобавок* заблокированы на сетевом/DPI-уровне (например, rutracker.org у некоторых провайдеров) — FlareSolverr решает JS-челлендж, но само соединение так и не уходит с его хоста через настроенный прокси.

**Исправление:** небольшой хелпер (`proxyOptionsToUrl`) превращает уже существующую пару `CURLOPT_PROXY`/`CURLOPT_PROXYTYPE` в строку вида `scheme://host:port`, которую ожидает JSON API FlareSolverr, а `getViaFlareSolverr()` включает её в тело запроса как `"proxy": {"url": "..."}`, когда для этого трекера настроен прокси. FlareSolverr уже поддерживает это поле (см. его README) — просто оно никогда не отправлялось.

Поведение не меняется, если для трекера прокси не настроен (`proxyOptionsToUrl` возвращает `null`, ключ `proxy` просто не добавляется). Проверено, что `php -l` проходит; на живом экземпляре FlareSolverr со сквозной передачей поля прокси не запускалось, поэтому, пожалуйста, сверьте имя/форму поля на стороне FlareSolverr с той версией, на которую вы ориентируетесь.

Контекст: мы держим TorrentMonitor self-hosted за прокси ровно из-за этой связки DPI+Cloudflare и обходили проблему дополнительным sidecar-сервисом, пока не заметили, насколько небольшой оказался пробел. Готов поправить патч, если вам предпочтительнее другой вариант (например, более прямое переиспользование формы вывода `getProxyOptions` или настройка-переключатель, отключающая проксирование именно для FlareSolverr).