### PR TITLE
Add Gotify notification channel

### DIFF
--- a/class/Notification.class.php
+++ b/class/Notification.class.php
@@ -114,7 +114,7 @@ class Notification
 	public static function sendPushall($pushall, $date, $tracker, $message, $header_message, $name)
 	{
     	$msg = Notification::generateMessage($date, $tracker, $message, $header_message, $name);
-        
+
         $pieces = explode(';', $pushall);
         $postfields = array('type' => 'self', 'id' => $pieces[0], 'key' => $pieces[1], 'title' => $header_message, 'text' => $msg);
         $forumPage = Sys::getUrlContent(
@@ -127,7 +127,28 @@ class Notification
             )
         );
 	}
-	
+
+	//self-hosted push (https://gotify.net/) -- адрес хранится как "серверUrl;appToken"
+	public static function sendGotify($gotify, $date, $tracker, $message, $header_message, $name)
+	{
+    	$msg = Notification::generateMessage($date, $tracker, $message, $header_message, $name);
+
+        $pieces = explode(';', $gotify);
+        if ( ! isset($pieces[1]))
+            return;
+        $url = rtrim($pieces[0], '/').'/message?token='.$pieces[1];
+        $postfields = array('title' => $header_message, 'message' => $msg, 'priority' => 5);
+        $forumPage = Sys::getUrlContent(
+            array(
+                'type'           => 'POST',
+                'returntransfer' => 1,
+                'url'            => $url,
+                'ssl_false'      => 1,
+                'postfields'     => $postfields,
+            )
+        );
+	}
+
     public static function sendTelegram($telegram, $date, $tracker, $message, $header_message, $name)
     {
         $msg = Notification::generateMessage($date, $tracker, $message, $header_message, $name);

--- a/db_schema/mysql.sql
+++ b/db_schema/mysql.sql
@@ -93,7 +93,9 @@ VALUES
 	(9,'Pushall','', 'notification'),
 	(10,'Pushall','', 'warning'),
 	(11,'Telegram','', 'notification'),
-	(12,'Telegram','', 'warning');
+	(12,'Telegram','', 'warning'),
+	(13,'Gotify','', 'notification'),
+	(14,'Gotify','', 'warning');
 
 UNLOCK TABLES;
 

--- a/db_schema/postgresql.sql
+++ b/db_schema/postgresql.sql
@@ -57,7 +57,7 @@ CREATE TABLE "news" (
 );
 
 
-CREATE SEQUENCE "auto_id_notifications" START 13;
+CREATE SEQUENCE "auto_id_notifications" START 15;
 
 CREATE TABLE "notifications" (
   "id" INTEGER  PRIMARY KEY NOT NULL DEFAULT nextval('auto_id_notifications'),
@@ -78,6 +78,8 @@ INSERT INTO notifications VALUES (9, 'Pushall', '', 'notification');
 INSERT INTO notifications VALUES (10, 'Pushall', '', 'warning');
 INSERT INTO notifications VALUES (11, 'Telegram', '', 'notification');
 INSERT INTO notifications VALUES (12, 'Telegram', '', 'warning');
+INSERT INTO notifications VALUES (13, 'Gotify', '', 'notification');
+INSERT INTO notifications VALUES (14, 'Gotify', '', 'warning');
 
 CREATE SEQUENCE "auto_id_settings" START 42;
 

--- a/db_schema/sqlite.sql
+++ b/db_schema/sqlite.sql
@@ -68,6 +68,8 @@ INSERT INTO "notifications" VALUES(9,'Pushall','','notification');
 INSERT INTO "notifications" VALUES(10,'Pushall','','warning');
 INSERT INTO "notifications" VALUES(11,'Telegram','','notification');
 INSERT INTO "notifications" VALUES(12,'Telegram','','warning');
+INSERT INTO "notifications" VALUES(13,'Gotify','','notification');
+INSERT INTO "notifications" VALUES(14,'Gotify','','warning');
 
 CREATE TABLE `settings` (
   `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,


### PR DESCRIPTION
Добавляет Gotify (https://gotify.net/) как канал уведомлений — закрывает #230.

**Что добавлено:** `Notification::sendGotify()`, по точно такому же образцу, как соседние `sendPushall()`/`sendPushover()` — адрес хранится одной строкой `"serverUrl;appToken"`, отправляет `title`/`message`/`priority` на `{server}/message?token={token}` согласно API Gotify. Засеян как сервис с id 13/14 во всех трёх файлах `db_schema/*.sql` (диспетчер в `sendNotification()` полностью динамический через `call_user_func`, так что никакой другой участок кода менять не потребовалось).

`priority` захардкожен в 5 (по умолчанию у Gotify 0; 5 даёт звук+вибрацию на большинстве клиентов, не будучи максимальным/always-on-top уровнем) — готов сделать его настраиваемым через третий сегмент, отделённый `;`, если вы не хотите хардкода.

**Две вещи, о которых стоит сказать до того, как вы посмотрите дифф:**

1. **Это помогает только новым установкам.** Я не нашёл в этом репозитории пути миграции для существующих баз — `class/Update.class.php` тянет query-миграции с `https://xml.tormon.ru/update.xml`, к которому у меня, очевидно, нет доступа на запись. Так что существующие установки не увидят Gotify в выпадающем списке, пока в этот update-фид не попадут те же два `INSERT`'а (и не будет поднята версия БД). Я с радостью выпишу точные запросы для всех трёх движков, если это будет полезно, но их выкладка — на вашей стороне.
2. **Последовательность в PostgreSQL:** в `db_schema/postgresql.sql` используется `CREATE SEQUENCE "auto_id_notifications" START 13` — поскольку я добавил строки с явными id 13/14, я поднял это до `START 15` тем же коммитом. Уточнение к тому, что я написал здесь изначально: я проверил — `INSERT INTO notifications` нигде в собственном коде этого репозитория нет, таблица только `SELECT`-ится/`UPDATE`-ится, так что `nextval()` фактически ниоткуда, что я вижу, не вызывается, и это поднятие — гигиена, а не исправление бага, который я могу воспроизвести. Одна оговорка: я не вижу SQL, который `class/Update.class.php` тянет с `https://xml.tormon.ru/update.xml` для миграций существующих установок — если там когда-либо вставляются строки без явных id, `nextval()` сработает именно там, и поднятие будет иметь реальное значение. Пока смотрел, я обнаружил такой же паттерн расхождения уже в живом виде в другом месте, чтобы вам не пришлось проверять это самому: в `db_schema/postgresql.sql` есть `CREATE SEQUENCE "auto_id_settings" START 42`, но id 42 (`ApiKey`) и 43 (`qbitCategory`) уже засеяны — та же скрытая проблема, не привнесённая этим PR. С `auto_id_credentials` всё в порядке (`START 24` против максимального засеянного id 23); в `news` засеянных строк нет, так что там проверять нечего.

`php -l` чисто на PHP 8.5. Сквозного теста на живом экземпляре Gotify не проводилось (multipart POST через существующий `Sys::getUrlContent()` должен соответствовать документированным для Gotify примерам `curl -F`, но отмечаю, что лично я это не проверял).