### PR TITLE
Классификация ошибок соединения: прокси vs трекер (closes #229)

### DIFF
--- a/class/CurlMultiFetcher.class.php
+++ b/class/CurlMultiFetcher.class.php
@@ -94,6 +94,7 @@ class CurlMultiFetcher
                 $body     = curl_multi_getcontent($ch);
                 $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
                 $error    = curl_error($ch);
+                $errno    = curl_errno($ch);
 
                 $meta = $this->requestMeta[$key];
 
@@ -125,6 +126,7 @@ class CurlMultiFetcher
                         'body'      => $body,
                         'http_code' => $httpCode,
                         'error'     => $error,
+                        'errno'     => $errno,
                     );
                 }
 

--- a/class/Errors.class.php
+++ b/class/Errors.class.php
@@ -11,6 +11,9 @@ class Errors
     	Errors::write('credential_miss', 'Не указаны учётные данные для трекера.');
 
 		Errors::write('not_available', 'Не могу получить доступ к трекеру.');
+		Errors::write('proxy_unreachable', 'Не удалось подключиться через прокси для этого трекера.');
+		Errors::write('proxy_path_unreachable', 'Соединение через прокси не установлено: недоступен прокси или трекер.');
+		Errors::write('tracker_unreachable', 'Трекер не отвечает: соединение не установлено.');
 		Errors::write('credential_wrong', 'Неправильные учётные данные.');
 		Errors::write('cant_get_forum_page', 'Не удалось получить страницу трекера.');
 		Errors::write('cant_get_auth_page', 'Не удалось получить страницу авторизацию трекера.');

--- a/class/System.class.php
+++ b/class/System.class.php
@@ -10,6 +10,10 @@ class Sys
     public static $lastCfCookies = '';
     public static $lastCfUserAgent = '';
 
+    // errno последнего curl_exec() в getUrlContent() — для классификации
+    // connectivity-ошибок вызывающим кодом без смены сигнатуры возврата
+    public static $lastCurlErrno = 0;
+
     //проверяем есть ли конфигурационный файл
     public static function checkConfigExist()
     {
@@ -276,6 +280,7 @@ class Sys
                 curl_setopt($ch, CURLOPT_VERBOSE, TRUE);
 
             $result   = curl_exec($ch);
+            Sys::$lastCurlErrno = curl_errno($ch);
             $httpCode = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
             curl_close($ch);
 
@@ -306,6 +311,21 @@ class Sys
 
             return $result;
         }
+    }
+
+    // Классифицирует последнюю curl-ошибку getUrlContent(): различает недоступность прокси
+    // от недоступности трекера через рабочий прокси. NULL = не connectivity-ошибка
+    // (например неверные креды при HTTP 200) — вызывающий код сам решает что делать.
+    public static function classifyConnectionError($url)
+    {
+        $errno = Sys::$lastCurlErrno;
+        if ($errno == 0)
+            return NULL;
+        if (in_array($errno, array(5, 97)))
+            return 'proxy_unreachable';
+        if ($errno == 7 && !empty(Sys::getProxyOptions($url)))
+            return 'proxy_path_unreachable';
+        return 'tracker_unreachable';
     }
 
     public static function isCloudflarePage(string $body): bool

--- a/engine.php
+++ b/engine.php
@@ -118,6 +118,7 @@ if (Sys::checkCurl())
 				            $pending[$key] = array(
 				                'row'   => $torrentsList[$i],
 				                'class' => $functionClass,
+				                'url'   => $requestParams['url'],
 				            );
 				        }
 				    }
@@ -154,8 +155,17 @@ if (Sys::checkCurl())
     {
         $row     = $info['row'];
         $class   = $info['class'];
+        $url     = $info['url'];
         $tracker = $row['tracker'];
-        $response = isset($responses[$key]) ? $responses[$key] : array('body' => '', 'http_code' => 0, 'error' => 'no response');
+        $response = isset($responses[$key]) ? $responses[$key] : array('body' => '', 'http_code' => 0, 'error' => 'no response', 'errno' => 0);
+
+        if ( ! empty($response['error']))
+        {
+            Sys::$lastCurlErrno = $response['errno'];
+            $connErr = Sys::classifyConnectionError($url);
+            if ($connErr !== NULL)
+                Errors::setWarnings($tracker, $connErr, $row['id']);
+        }
 
         $time_start = microtime(true);
         try {

--- a/include/check.php
+++ b/include/check.php
@@ -149,8 +149,11 @@ if ($memoryLimitBytes > 0 && $memoryLimitBytes < 64 * 1024 * 1024) { ?>
 if ($dbOk) {
 if ($internetOk) { ?>
     <div class="check-item">Подключение к интернету установлено.</div>
-<?php } else { ?>
-    <div class="check-item --error">Отсутствует подключение к интернету.</div>
+<?php } else {
+    $internetErr   = $checkResults['internet']['error'] ?? '';
+    $internetProxy = ! empty($internetErr) ? Sys::getProxyOptions(Sys::INTERNET_CHECK_URL) : array();
+    ?>
+    <div class="check-item --error"><?php if ( ! empty($internetProxy)) { ?>Не удалось соединиться через прокси: <?= htmlspecialchars($internetErr, ENT_QUOTES) ?> — недоступен прокси либо целевой узел, интернет как таковой может работать.<?php } elseif ( ! empty($internetErr)) { ?>Отсутствует подключение к интернету: <?= htmlspecialchars($internetErr, ENT_QUOTES) ?>.<?php } else { ?>Ответ получен, но не похож на рабочую страницу — проверьте доступ к <?= htmlspecialchars(Sys::INTERNET_CHECK_URL, ENT_QUOTES) ?>.<?php } ?></div>
 <?php }
 } ?>
 
@@ -261,9 +264,9 @@ if ($rootFree === false) { ?>
         if ($available) { ?>
     <div class="check-item">Торрент-клиент по адресу <strong><?= htmlspecialchars($torrentAddress, ENT_QUOTES) ?></strong> отвечает.</div>
         <?php } elseif ($torrentClient == 'Deluge') { ?>
-    <div class="check-item --error">Торрент-клиент по адресу <strong><?= htmlspecialchars($torrentAddress, ENT_QUOTES) ?></strong> не отвечает. Для Deluge укажите адрес и порт <strong>deluge-web</strong> (по умолчанию 8112), а не порт демона (58846).</div>
+    <div class="check-item --error">Торрент-клиент по адресу <strong><?= htmlspecialchars($torrentAddress, ENT_QUOTES) ?></strong> не отвечает<?= ! empty($result['error']) ? ': '.htmlspecialchars($result['error'], ENT_QUOTES) : '' ?>. Для Deluge укажите адрес и порт <strong>deluge-web</strong> (по умолчанию 8112), а не порт демона (58846).</div>
         <?php } else { ?>
-    <div class="check-item --error">Торрент-клиент по адресу <strong><?= htmlspecialchars($torrentAddress, ENT_QUOTES) ?></strong> не отвечает.</div>
+    <div class="check-item --error">Торрент-клиент по адресу <strong><?= htmlspecialchars($torrentAddress, ENT_QUOTES) ?></strong> не отвечает<?= ! empty($result['error']) ? ': '.htmlspecialchars($result['error'], ENT_QUOTES) : '' ?>.</div>
         <?php }
     } ?>
 
@@ -358,7 +361,7 @@ foreach ($credentials as $cred)
     ?>
     <div class="check-item">Трекер <strong><?= htmlspecialchars($tracker, ENT_QUOTES) ?></strong> доступен<?= $behindCf ? ' (за Cloudflare)' : '' ?>.</div>
     <?php } else { ?>
-    <div class="check-item --error">Трекер <strong><?= htmlspecialchars($tracker, ENT_QUOTES) ?></strong> не доступен.</div>
+    <div class="check-item --error">Трекер <strong><?= htmlspecialchars($tracker, ENT_QUOTES) ?></strong> не доступен<?= ! empty($result['error']) ? ': '.htmlspecialchars($result['error'], ENT_QUOTES) : '' ?>.</div>
     <?php
     } ?>
 <?php }

--- a/trackers/rutracker.org.engine.php
+++ b/trackers/rutracker.org.engine.php
@@ -114,7 +114,15 @@ class rutracker
 		}
 		else
 		{
-			if (rutracker::$warning == NULL) { rutracker::$warning = TRUE; Errors::setWarnings($tracker, 'cant_get_auth_page'); }
+			if (rutracker::$warning == NULL)
+			{
+				rutracker::$warning = TRUE;
+				$connErr = Sys::classifyConnectionError($loginUrl);
+				if ($connErr !== NULL)
+					Errors::setWarnings($tracker, $connErr);
+				else
+					Errors::setWarnings($tracker, 'cant_get_auth_page');
+			}
 		}
 		rutracker::$exucution = FALSE;
 	}


### PR DESCRIPTION
Closes #229

## Суть

В issue просили возможность различать «лежит трекер» и «лежит прокси, через который его опрашивают». В треде прозвучало возражение, что для этого пришлось бы анализировать логи, чего ТМ делать не умеет. При разборе кода выяснилось, что анализ логов и не нужен: **вся необходимая информация уже есть в памяти процесса в момент ошибки, она просто выбрасывается**.

Конкретно:

- `class/CurlMultiFetcher.class.php` уже вычисляет `curl_error()` для каждого запроса при опросе раздач — но в `engine.php` этот результат не используется, вместо него ставится обобщённый варнинг.
- `System::getUrlContent()` (через него ходят ~25 трекерных движков — логин, куки, скачивание) вызывает `curl_exec()`, но никогда не проверяет `curl_errno()`.
- На странице «Тестирование» (`include/check.php`) результат сводится к бинарному «доступен / не доступен» без причины.

`curl_errno()` уже различает «не резолвится/не отвечает прокси» и «не отвечает целевой хост» — достаточно донести этот код до существующего механизма варнингов.

## Что сделано

1. **`CurlMultiFetcher`** — в результат запроса дополнительно кладётся `errno` (раньше был только текст ошибки).
2. **`System::getUrlContent()`** — сохраняет `curl_errno()` в новое статическое поле `Sys::$lastCurlErrno`. Использован тот же паттерн, что уже есть в этом классе для `$lastCfCookies` / `$lastCfUserAgent`: сигнатура возврата не меняется, ~25 вызывающих файлов трогать не пришлось.
3. **Новый метод `Sys::classifyConnectionError($url)`** — по errno классифицирует ошибку:
   - `proxy_unreachable` (errno 5/97) — DNS прокси не резолвится / ошибка прокси-протокола;
   - `proxy_path_unreachable` (errno 7 при настроенном прокси) — SOCKS5 не позволяет различить «прокси не поднялся» и «прокси ответил host unreachable для цели», поэтому код честно называет этот случай неоднозначным, а не сваливает вину на прокси;
   - `tracker_unreachable` — остальные connectivity-ошибки, включая таймаут (таймаут через рабочий прокси чаще означает зависший трекер, а не прокси).
   - Если `errno == 0` (соединение установлено, ответ получен — например HTTP 403 или неверные креды) — метод возвращает `NULL`, и вызывающий код работает ровно как раньше. Новый механизм не подменяет обработку не-connectivity ошибок.
4. **`class/Errors.class.php`** — три новых кода ошибок (`proxy_unreachable`, `proxy_path_unreachable`, `tracker_unreachable`). Записываются через уже существующий `Errors::setWarnings()` — новой схемы БД и нового UI не потребовалось.
5. **`engine.php`** — перед тем как движок трекера начнёт парсить страницу: если в ответе была curl-ошибка, она классифицируется и ставится соответствующий варнинг; если это не connectivity-проблема — поведение прежнее, решает штатный код трекера.
6. **`trackers/rutracker.org.engine.php`** — та же классификация добавлена на ветку логина, где раньше на все случаи ставился один обобщённый `cant_get_auth_page`. Это **единственный** изменённый движок из ~25 — на нём я реально работаю и мог проверить вживую. Остальные 24 сознательно не тронуты: расширить их по аналогии можно тем же готовым `Sys::classifyConnectionError()`.
7. **`include/check.php`** — три места, где раньше был бинарный «доступен / не доступен», теперь показывают текст реальной curl-ошибки. Попутно в рамках того же разбора найден и исправлен баг: проверка интернета (`ya.ru` через настроенный прокси) при неуспехе всегда писала «отсутствует подключение к интернету», даже когда curl отработал без единой ошибки (просто HTTP-код/тело не прошли эвристику). Теперь текст различает «реальная curl-ошибка через прокси» / «реальная curl-ошибка без прокси» / «ответ получен, но не похож на рабочую страницу» — раньше это могло ложно указывать на прокси там, где прокси ни при чём.

## Что проверено

- Все 6 изменённых файлов проходят `php -l` на актуальном образе `alfonder/torrentmonitor:latest`.
- **Живой сценарий «прокси недоступен при логине»**: свежая неавторизованная сессия, реальный аккаунт rutracker.org через SOCKS5-прокси, прокси остановлен — curl получает таймаут (errno 28). До патча: обобщённый `cant_get_auth_page`, ничего не говорящий о причине. После патча: `tracker_unreachable` с реальной причиной.
- **Живой сценарий «трекер ответил отказом»**: реальный HTTP 403 от rutracker.org (errno = 0, соединение установлено). Код корректно **не** классифицировал это как connectivity-проблему — ложных срабатываний нет, прежнее поведение сохранено.

## Что не проверено (честно)

- Ветки `proxy_unreachable` (errno 5/97) и `proxy_path_unreachable` (errno 7) вживую продемонстрировать не удалось. Эти ветки проверены только код-ревью, не живым прогоном.
- Из ~25 трекерных движков изменён и протестирован только rutracker.org — остальные не тронуты и не тестировались.

## Открытые вопросы к обсуждению

- Устраивает ли такой scope (rutracker.org как образец + готовая инфраструктура для остальных движков), или стоит сразу раскатать классификацию на другие трекеры?
- Названия кодов ошибок (`proxy_unreachable` / `proxy_path_unreachable` / `tracker_unreachable`) — если видите их иначе, переименую без проблем.

Буду рад замечаниям — если что-то в подходе не устраивает, готов переработать.
