### PR TITLE
SynologyDS: _find_id() матчит по uri раздачи, не берёт последний таск

### DIFF
--- a/class/SynologyDS.class.php
+++ b/class/SynologyDS.class.php
@@ -70,7 +70,7 @@ class SynologyDS
         return FALSE;
     }
 
-    private static function _find_id($sid)
+    private static function _find_id($sid, $url)
     {
         $list = SynologyDS::_list_downloads($sid);
         if ($list === NULL)
@@ -79,7 +79,8 @@ class SynologyDS
         $id = NULL;
         foreach ($list->data->tasks as $task)
         {
-            $id = $task->id;
+            if ($task->additional->detail->uri == $url)
+                $id = $task->id;
         }
         return $id;
     }
@@ -159,7 +160,13 @@ class SynologyDS
                     }
                     else
                     {
-                        $hashNew = SynologyDS::_find_id($sid);
+                        $hashNew = NULL;
+                        for ($attempt = 0; $attempt < 3 && $hashNew === NULL; $attempt++)
+                        {
+                            if ($attempt > 0)
+                                sleep(1);
+                            $hashNew = SynologyDS::_find_id($sid, $file);
+                        }
                         if ($hashNew)
                         {
                             Database::updateHash($id, $hashNew);


### PR DESCRIPTION
## Проблема

`SynologyDS::_find_id($sid)` вызывается из `addNew()` сразу после успешного создания задачи в Download Station, чтобы получить её id. Но метод устроен так:

```php
$id = NULL;
foreach ($list->data->tasks as $task)
{
    $id = $task->id;
}
return $id;
```

Он просто перебирает **все** активные задачи пользователя и возвращает id последней в списке — без какой-либо привязки к только что созданной задаче. Если активная закачка одна, всё случайно работает. Если их больше одной (обычный сценарий: TorrentMonitor следит за несколькими темами, плюс пользователь мог добавить что-то вручную через тот же Download Station) — метод возвращает id **посторонней** задачи.

## Почему это не косметика

1. Неверный id сохраняется в базу через `Database::updateHash($id, $hashNew)` как hash отслеживаемой раздачи.
2. При следующем обновлении темы (вышла новая серия) код выполняет `delete&id=<сохранённый id>`, чтобы убрать «старую» раздачу перед добавлением новой. Но сохранённый id указывает на чужую, всё ещё активную задачу — и она **реально удаляется** из Download Station, хотя к TorrentMonitor вообще не относится.

То есть баг приводит к тихой потере пользовательских закачек, не связанных с мониторингом.

Примечательно, что соседний метод в этом же файле — `_download_already_exists($sid, $url)` — устроен корректно: он матчит задачу по `$task->additional->detail->uri == $url`. `_find_id` — единственное место в файле, которое так не делает.

## Что исправлено

1. **`_find_id($sid, $url)`** — теперь принимает URL и матчит задачу по `$task->additional->detail->uri == $url`, тем же полем и тем же паттерном, что уже использует `_download_already_exists`. Ничего нового не изобретается.
2. При совпадении **берётся последнее совпадение по списку, а не первое**: удаление старой задачи в Synology асинхронно, и в момент запроса списка старая (уже помеченная на удаление) задача с тем же uri теоретически может ещё числиться рядом с новой. Последняя по порядку — либо единственная, либо самая свежая.
3. **Bounded retry в `addNew()`** (до 3 попыток с `sleep(1)`): между `create` и `list` возможна гонка — API может не успеть проиндексировать только что созданную задачу. Без retry это давало бы `add_fail` и запись попадала бы в очередь повторов (`temp`) — где повторная попытка передаёт пустой hash, срабатывает проверка на дубликат, и запись зависает в очереди навсегда, так и не получив корректный hash. Прецедент такого ожидания после add уже есть в репозитории: `class/qBittorrent.class.php` делает `sleep(3)` после успешного добавления.

Смена сигнатуры `_find_id` безопасна: метод `private static`, единственный вызов — внутри этого же файла (`grep -rn "_find_id"` по всему репозиторию даёт ровно два совпадения: определение и один вызов).

## Что проверено

- Синтаксис (`php -l`).
- Логику патча (в частности edge case с гонкой create→list) несколько раз перепроверял вручную — из-за этого в финальной версии появились retry и выбор последнего совпадения по uri, а не первая рабочая версия.
- Формат ответов `SYNO.DownloadStation.Task` (включая `additional->detail->uri`) сверен live read-only запросами к реальному DSM.

## Что НЕ проверено (честно)

Живой e2e-тест с созданием реальной задачи в Download Station сознательно не выполнялся — это запустило бы настоящее скачивание на моём личном NAS. Поэтому патч проверен статически и логически, но не прогонялся вживую от `addNew()` до `updateHash()`.

Если вы видите другую стратегию идентификации созданной задачи (например, если у какой-то версии API есть способ получить id прямо из ответа `create`) — с удовольствием переделаю, буду рад обсуждению.
