### PR TITLE
Исправление: категория не сохраняется при редактировании сериала (тихий no-op в updateSerial)

### DIFF
--- a/action.php
+++ b/action.php
@@ -258,7 +258,7 @@ if (isset($_POST['action']))
 			$class = explode('.', $tracker);
 			$class = $class[0];
 			$class = str_replace('-', '', $class);
-			Database::updateSerial($_POST['id'], $_POST['name'], $_POST['path'], $_POST['hd'], Sys::strBoolToInt($_POST['reset']), $_POST['script'], Sys::strBoolToInt($_POST['pause']));
+			Database::updateSerial($_POST['id'], $_POST['name'], $_POST['path'], $_POST['hd'], Sys::strBoolToInt($_POST['reset']), $_POST['script'], Sys::strBoolToInt($_POST['pause']), $_POST['category'] ?? '');
 			$return['error'] = FALSE;
             $return['msg'] = 'Сериал обновлён.';
         }

--- a/class/Database.class.php
+++ b/class/Database.class.php
@@ -832,18 +832,19 @@ class Database
             return FALSE;
     }
 
-    public static function updateSerial($id, $name, $path, $hd, $reset, $script, $pause)
+    public static function updateSerial($id, $name, $path, $hd, $reset, $script, $pause, $category = '')
     {
         if ($reset)
-            $stmt = self::newStatement("UPDATE `torrent` SET `name` = :name, `path` = :path, `hd` = :hd, `ep` = '', `timestamp` = '2000-01-01 00:00:00', `hash` = '', `script` = :script, `pause` = :pause WHERE `id` = :id");
+            $stmt = self::newStatement("UPDATE `torrent` SET `name` = :name, `path` = :path, `hd` = :hd, `ep` = '', `timestamp` = '2000-01-01 00:00:00', `hash` = '', `script` = :script, `pause` = :pause, `category` = :category WHERE `id` = :id");
         else
-            $stmt = self::newStatement("UPDATE `torrent` SET `name` = :name, `path` = :path, `hd` = :hd, `script` = :script, `pause` = :pause WHERE `id` = :id");
+            $stmt = self::newStatement("UPDATE `torrent` SET `name` = :name, `path` = :path, `hd` = :hd, `script` = :script, `pause` = :pause, `category` = :category WHERE `id` = :id");
         $stmt->bindParam(':name', $name);
         $stmt->bindParam(':path', $path);
         $stmt->bindParam(':script', $script);
         $stmt->bindParam(':hd', $hd);
         $stmt->bindParam(':id', $id);
         $stmt->bindParam(':pause', $pause);
+        $stmt->bindParam(':category', $category);
         if ($stmt->execute())
             return TRUE;
         else


### PR DESCRIPTION
Здравствуйте!

Разбирая issue #223 (категории qBittorrent), попутно наткнулся на самостоятельный баг — этот PR не является фиксом #223, но тесно связан по теме.

## Симптом

Для сериальных трекеров (lostfilm.tv / lostfilm-mirror / newstudio.tv / baibako.tv): при **редактировании** уже добавленного сериала в веб-интерфейсе изменение поля «Категория» тихо теряется. Форма показывает поле, после сохранения выводится «Сериал обновлён», но значение в базе не меняется. При этом при **добавлении** сериала категория сохраняется корректно.

## Причина

Цепочка обрывается на бэкенде:

- `pages/_modal-edit.php` — форма собирает значение (`name="category" x-model="editData.category"`), т.е. UI свою часть делает;
- `action.php` (ветка `action == 'update'` для сериалов) — вызывает `Database::updateSerial(...)`, но `$_POST['category']` для этого пути вообще не читается;
- `class/Database.class.php`, метод `updateSerial()` — не принимает параметр `category`, и обе SQL-ветки (`reset` / без `reset`) не трогают колонку `category` таблицы `torrent`.

Для сравнения: соседний метод того же семейства `updateThreme()` уже несёт `$category = ''` и пишет `category = :category` в SQL. Судя по коду, `updateSerial` — единственный оставшийся метод, не догнавший эту миграцию (`setSerial` / `setThreme` / `updateThreme` / REST API категорию уже умеют).

## Изменение

Приводит `updateSerial` к тому же паттерну, что уже применён в `updateThreme`:

1. `class/Database.class.php`: сигнатура `updateSerial(..., $pause, $category = '')`, в обе SQL-ветки добавлено `` `category` = :category ``, плюс соответствующий `bindParam`.
2. `action.php`: в вызов `updateSerial` для сериалов добавлен восьмой аргумент `$_POST['category'] ?? ''`.

Ключевая строка — новая сигнатура (было / стало):

```php
// было
public static function updateSerial($id, $name, $path, $hd, $reset, $script, $pause)

// стало
public static function updateSerial($id, $name, $path, $hd, $reset, $script, $pause, $category = '')
```

Полный дифф — во вкладке Files changed, он небольшой.

## Как тестировалось

На вашем официальном Docker-образе (PHP 8.5.9), в одноразовом чистом контейнере:

- синтаксис-проверка (`php -l`);
- функционально: редактирование сериала с изменением категории — значение теперь реально доезжает до БД, проверено для обоих вариантов (`reset` включён и выключен);
- обратная совместимость: редактирование без изменения категории и старое поведение остальных полей не затронуты.

## Известный trade-off (осознанный)

Если где-то в будущем `updateSerial()` будет вызван без восьмого аргумента, категория обнулится (дефолт `$category = ''`). Это ровно то же поведение, что уже есть у `updateThreme`, — не новый риск, а тот же контракт.

## Что осознанно вне рамок этого PR

Фикс касается только сохранения категории в БД. **Не проверялось**, применяется ли изменённая категория к уже добавленной (существующей) раздаче непосредственно в самом qBittorrent — судя по `class/qBittorrent.class.php`, категория выставляется только на этапе добавления раздачи. Если важно протягивать смену категории и в уже работающий торрент, это отдельная, более крупная задача — могу завести issue, если считаете нужным.

Спасибо за проект! Буду рад замечаниям по реализации.